### PR TITLE
refactor: restructure and document `ErrorKind` variants by category

### DIFF
--- a/src/model/json_parse_error.rs
+++ b/src/model/json_parse_error.rs
@@ -1,76 +1,218 @@
-// src/model/json_parse_error.rs
+use std::error::Error;
+use std::fmt;
 
-/// Represents an error encountered while parsing JSON.
+/// Enumerates the kinds of parsing errors that may occur when decoding JSON.
+#[derive(Debug, PartialEq)]
+pub enum ErrorKind {
+    // ────────────────────────────────
+    // Syntax-level expectations
+    // ────────────────────────────────
+    /// A colon `:` was expected (e.g., after a key in an object).
+    ExpectedColon,
+
+    /// A comma `,` was expected (e.g., between array elements or object members).
+    ExpectedComma,
+
+    /// A string key was expected but not found (e.g., in an object).
+    ExpectedStringKey,
+
+    /// A JSON value was expected (e.g., number, object, array, etc.).
+    ExpectedValue,
+
+    // ────────────────────────────────
+    // Unexpected tokens or characters
+    // ────────────────────────────────
+    /// A closing bracket `]` was expected (e.g., to end an array).
+    ExpectedBracket,
+
+    /// A closing brace `}` was expected (e.g., to end an object).
+    ExpectedBrace,
+
+    /// An unexpected character was found (e.g., a `}` instead of `,`).
+    UnexpectedChar(char),
+
+    /// The input ended unexpectedly before completing a valid value.
+    UnexpectedEof,
+
+    // ────────────────────────────────
+    // String-related issues
+    // ────────────────────────────────
+    /// An invalid escape sequence was encountered (e.g., `\q`).
+    InvalidEscape,
+
+    /// A malformed Unicode escape was encountered (e.g., `\uZZZZ`).
+    InvalidUnicode,
+
+    /// The string literal was not properly closed with a `"` character.
+    UnterminatedString,
+
+    // ────────────────────────────────
+    // Number-related issues
+    // ────────────────────────────────
+    /// Decimal point is not followed by digits (e.g., `5.`).
+    DecimalWithoutDigits,
+
+    /// Exponent part is malformed (e.g., `1e`, `2e+`).
+    InvalidExponent,
+
+    /// Number format is invalid (e.g., trailing comma: `1,`).
+    InvalidNumber,
+
+    /// Integer has leading zeros, which are not allowed (e.g., `01`).
+    LeadingZero,
+
+    // ────────────────────────────────
+    // Object-related issues
+    // ────────────────────────────────
+    /// An invalid object key was encountered (e.g., a number instead of a string).
+    InvalidObjectKey,
+
+    /// A trailing comma was found before a closing brace or bracket (e.g., `[1,]`).
+    TrailingComma,
+
+    // ────────────────────────────────
+    // Catch-all
+    // ────────────────────────────────
+    /// A parser-defined error with a custom message.
+    Custom(String),
+}
+
+/// Represents a detailed error that occurred while parsing a JSON input.
 #[derive(Debug, PartialEq)]
 pub struct JsonParseError {
-    pub message: String,
+    /// Byte offset in the input where the error occurred.
     pub index: usize,
+
+    /// Line number (1-based) where the error occurred.
     pub line: usize,
+
+    /// Column number (1-based) on the line where the error occurred.
     pub column: usize,
+
+    /// The kind of error that occurred.
+    pub kind: ErrorKind,
+
+    /// A short snippet of the input near the error for context.
+    pub snippet: String,
 }
 
 impl JsonParseError {
-    /// Creates a new `JsonParseError` with computed line and column information.
+    /// Creates a new `JsonParseError` with structured metadata.
     ///
-    /// This constructor calculates the human-readable location (line and column)
-    /// corresponding to a byte index in the original JSON input. Useful for surfacing
-    /// precise error locations in CLI tools, editors, or debugging output.
+    /// This function computes the line, column, and input snippet context
+    /// from a raw byte offset in the original JSON input.
     ///
     /// # Arguments
     ///
-    /// * `message` - A description of the parsing error.
-    /// * `position` - The byte index in the input string where the error occurred.
-    /// * `input` - The original JSON input string.
+    /// * `input` - The full input string that was being parsed.
+    /// * `position` - The byte index in the input where the error occurred.
+    /// * `kind` - The kind of error encountered (`ErrorKind`).
     ///
     /// # Returns
     ///
-    /// A fully populated `JsonParseError` with message, byte index, line, and column.
+    /// A fully constructed `JsonParseError` including line, column, and snippet.
     ///
     /// # Examples
     ///
     /// ```
-    /// use synson::model::json_parse_error::JsonParseError;
+    /// use synson::model::{JsonParseError, ErrorKind};
     ///
-    /// let err = JsonParseError::new("Unexpected token", 15, "{ \"a\": tru }");
-    /// assert_eq!(err.message, "Unexpected token");
-    /// assert_eq!(err.index, 15);
+    /// let input = "{ \"a\": tru }";
+    /// let err = JsonParseError::new(input, 8, ErrorKind::UnexpectedChar('t'));
+    ///
     /// assert_eq!(err.line, 1);
-    /// assert_eq!(err.column, 13);
+    /// assert_eq!(err.column, 9);
+    /// assert!(err.snippet.contains("tru"));
     /// ```
-    pub fn new(message: &str, position: usize, input: &str) -> Self {
-        let mut line = 1;
-        let mut column = 1;
-        for (_, c) in input.char_indices().take(position) {
-            if c == '\n' {
-                line += 1;
-                column = 1;
-            } else {
-                column += 1;
-            }
-        }
+    pub fn new(input: &str, position: usize, kind: ErrorKind) -> Self {
+        let (line, column) = compute_line_column(input, position);
+        let snippet = extract_snippet(input, position);
 
         Self {
-            message: message.to_string(),
+            kind,
             index: position,
             line,
             column,
+            snippet,
         }
     }
-
-    /// Creates a generic fallback error when a value parser fails to match its expected literal.
+    /// Creates a generic fallback error for a failed literal match.
     ///
-    /// This should only be used when the parser is *not* confident that the input was intended
-    /// for this type (e.g. `parse_null` called on `{"key": 1}`).
+    /// This is typically used when attempting to match a fixed keyword like `"null"` or `"true"`,
+    /// and no confident match was found.
     ///
     /// # Arguments
     ///
-    /// * `expected` - The name of the expected literal (e.g. `"null"`).
-    /// * `input` - The input slice being parsed.
+    /// * `expected` - The name of the literal that was expected (e.g., `"null"`).
+    /// * `input` - The current slice of JSON input being parsed.
     ///
     /// # Returns
     ///
-    /// A `JsonParseError` with a low-priority message suitable for fallback diagnostics.
+    /// A `JsonParseError` with kind `Custom`, starting at index 0.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use synson::model::{JsonParseError, ErrorKind};
+    ///
+    /// let err = JsonParseError::unmatched("null", "not_null");
+    ///
+    /// assert_eq!(err.index, 0);
+    /// assert!(matches!(err.kind, ErrorKind::Custom(ref msg) if msg.contains("Expected 'null'")));
+    /// ```
     pub fn unmatched(expected: &str, input: &str) -> Self {
-        Self::new(&format!("Expected '{expected}' literal"), 0, input)
+        Self::new(
+            input,
+            0,
+            ErrorKind::Custom(format!("Expected '{expected}' literal")),
+        )
     }
 }
+
+/// Computes the 1-based (line, column) from a byte offset in the input string.
+///
+/// This is used to generate human-readable error locations.
+fn compute_line_column(input: &str, offset: usize) -> (usize, usize) {
+    let mut line = 1;
+    let mut col = 1;
+    for (i, c) in input.char_indices() {
+        if i >= offset {
+            break;
+        }
+        if c == '\n' {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
+        }
+    }
+    (line, col)
+}
+
+/// Extracts a short context snippet around the given offset in the input.
+///
+/// This helps visualize where in the input the error occurred, useful for CLI feedback.
+///
+/// # Returns
+///
+/// A formatted snippet string like `"near '...error_here...'"`.
+fn extract_snippet(input: &str, offset: usize) -> String {
+    const CONTEXT: usize = 10;
+    let start = offset.saturating_sub(CONTEXT);
+    let end = usize::min(input.len(), offset + CONTEXT);
+    let snippet = &input[start..end];
+    format!("near '{}'", snippet.escape_default())
+}
+
+impl fmt::Display for JsonParseError {
+    /// Formats the error as a user-friendly diagnostic message.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Parse error at line {}, column {}: {:?} ({})",
+            self.line, self.column, self.kind, self.snippet
+        )
+    }
+}
+
+impl Error for JsonParseError {}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -2,6 +2,7 @@ pub mod json_parse_error;
 pub mod json_parse_options;
 pub mod json_value;
 
+pub use json_parse_error::ErrorKind;
 pub use json_parse_error::JsonParseError;
 pub use json_parse_options::JsonParseOptions;
 pub use json_value::JsonValue;

--- a/src/parser/bool.rs
+++ b/src/parser/bool.rs
@@ -1,4 +1,4 @@
-use crate::model::{JsonParseError, JsonValue};
+use crate::model::{ErrorKind, JsonParseError, JsonValue};
 
 /// Parses a JSON boolean literal (`true` or `false`) with strict syntax validation.
 ///
@@ -7,7 +7,7 @@ use crate::model::{JsonParseError, JsonValue};
 ///
 /// # Arguments
 ///
-/// * `input` - A string slice expected to start with a JSON boolean.
+/// * `input` - A string slice expected to start with a JSON boolean literal.
 ///
 /// # Returns
 ///
@@ -32,10 +32,11 @@ pub fn parse_bool(input: &str) -> Result<(JsonValue, &str), JsonParseError> {
     if let Some(rest) = input.strip_prefix("true") {
         if let Some(c) = rest.chars().next() {
             if c.is_ascii_alphanumeric() {
+                let pos = input.len() - rest.len();
                 return Err(JsonParseError::new(
-                    "Invalid token after 'true'",
-                    input.len() - rest.len(),
                     input,
+                    pos,
+                    ErrorKind::UnexpectedChar(c),
                 ));
             }
         }
@@ -45,10 +46,11 @@ pub fn parse_bool(input: &str) -> Result<(JsonValue, &str), JsonParseError> {
     if let Some(rest) = input.strip_prefix("false") {
         if let Some(c) = rest.chars().next() {
             if c.is_ascii_alphanumeric() {
+                let pos = input.len() - rest.len();
                 return Err(JsonParseError::new(
-                    "Invalid token after 'false'",
-                    input.len() - rest.len(),
                     input,
+                    pos,
+                    ErrorKind::UnexpectedChar(c),
                 ));
             }
         }

--- a/src/parser/json.rs
+++ b/src/parser/json.rs
@@ -1,4 +1,4 @@
-use crate::model::{JsonParseError, JsonParseOptions, JsonValue};
+use crate::model::{ErrorKind, JsonParseError, JsonParseOptions, JsonValue};
 use crate::parser::parse_value;
 
 /// Parses a complete JSON value from a string slice, ensuring full input consumption.
@@ -26,6 +26,7 @@ use crate::parser::parse_value;
 /// * `Err(JsonParseError)` if parsing fails or extra content remains after the parsing is completed.
 ///
 /// # Examples
+///
 /// ```
 /// use synson::{parse_json, JsonValue};
 /// use synson::model::JsonParseOptions;
@@ -44,17 +45,17 @@ pub fn parse_json(
 ) -> Result<JsonValue, JsonParseError> {
     let trimmed_input = input.trim_start();
     let (value, rest) = parse_value(trimmed_input)?;
-    let rest_trimmed = rest.trim_start();
 
+    let rest_trimmed = rest.trim_start();
     let default_options = JsonParseOptions::default();
     let options = options.unwrap_or(&default_options);
 
     if !rest_trimmed.is_empty() && options.strict {
         let offset = input.len() - rest_trimmed.len();
         return Err(JsonParseError::new(
-            "Trailing characters after JSON value",
-            offset,
             input,
+            offset,
+            ErrorKind::Custom("Trailing characters after JSON value".into()),
         ));
     }
 

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,9 +1,13 @@
+use synson::model::ErrorKind;
 use synson::parse_json;
 
 #[test]
 fn should_report_trailing_characters_error() {
     let err = parse_json("true false", None).unwrap_err();
-    assert_eq!(err.message, "Trailing characters after JSON value");
+    assert!(matches!(
+        err.kind,
+        ErrorKind::Custom(ref msg) if msg.contains("Trailing characters")
+    ));
     assert_eq!(err.index, 5);
     assert_eq!(err.line, 1);
     assert_eq!(err.column, 6);
@@ -12,36 +16,78 @@ fn should_report_trailing_characters_error() {
 #[test]
 fn should_report_missing_colon_in_object() {
     let err = parse_json("{\"key\" \"value\"}", None).unwrap_err();
-    assert_eq!(err.message, "Expected ':' after key in object");
+    assert!(matches!(err.kind, ErrorKind::ExpectedColon));
     assert_eq!(err.line, 1);
 }
 
 #[test]
 fn should_report_trailing_comma_in_array() {
     let err = parse_json("[true, false,]", None).unwrap_err();
-    assert_eq!(err.message, "Trailing comma not allowed before ']'");
+    assert!(matches!(err.kind, ErrorKind::TrailingComma));
 }
 
 #[test]
 fn should_report_unterminated_string() {
     let err = parse_json("\"unclosed string", None).unwrap_err();
-    assert_eq!(err.message, "Unterminated string literal");
+    assert!(matches!(err.kind, ErrorKind::UnterminatedString));
 }
 
 #[test]
 fn should_report_bad_escape_sequence() {
     let err = parse_json("\"bad\\escape\"", None).unwrap_err();
-    assert_eq!(err.message, "Invalid escape sequence in string");
+    assert!(matches!(err.kind, ErrorKind::InvalidEscape));
 }
 
 #[test]
 fn should_report_invalid_number_exponent() {
     let err = parse_json("1e", None).unwrap_err();
-    assert_eq!(err.message, "Missing digits in exponent");
+    assert!(matches!(err.kind, ErrorKind::InvalidExponent));
 }
 
 #[test]
 fn should_report_leading_zero_error() {
     let err = parse_json("01", None).unwrap_err();
-    assert_eq!(err.message, "Leading zeros are not allowed in numbers");
+    assert!(matches!(err.kind, ErrorKind::LeadingZero));
+}
+
+#[test]
+fn should_reject_non_string_object_keys() {
+    let err = parse_json("{123: true}", None).unwrap_err();
+    assert!(matches!(err.kind, ErrorKind::InvalidObjectKey));
+}
+
+#[test]
+fn should_reject_double_comma_in_array() {
+    let err = parse_json("[1,,2]", None).unwrap_err();
+    assert!(matches!(err.kind, ErrorKind::ExpectedValue));
+}
+
+#[test]
+fn should_reject_completely_invalid_start() {
+    let err = parse_json("!invalid", None).unwrap_err();
+    assert!(matches!(err.kind, ErrorKind::UnexpectedChar('!')));
+}
+
+#[test]
+fn should_report_invalid_unicode_escape() {
+    let err = parse_json("\"\\uXYZ1\"", None).unwrap_err();
+    assert!(matches!(err.kind, ErrorKind::InvalidUnicode));
+}
+
+#[test]
+fn should_report_invalid_surrogate_pair() {
+    let err = parse_json("\"\\uD83D\\u1234\"", None).unwrap_err();
+    assert!(matches!(err.kind, ErrorKind::InvalidUnicode));
+}
+
+#[test]
+fn should_reject_lonely_high_surrogate() {
+    let err = parse_json("\"\\uD800\"", None).unwrap_err();
+    assert!(matches!(err.kind, ErrorKind::InvalidUnicode));
+}
+
+#[test]
+fn should_reject_decimal_with_no_digits() {
+    let err = parse_json("1.", None).unwrap_err();
+    assert!(matches!(err.kind, ErrorKind::DecimalWithoutDigits));
 }

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use synson::model::JsonParseOptions;
+use synson::model::{ErrorKind, JsonParseOptions};
 use synson::{parse_json, JsonValue};
 
 #[test]
@@ -32,7 +32,10 @@ fn should_reject_invalid_json_values() {
 #[test]
 fn should_report_trailing_characters_error() {
     let err = parse_json("true false", None).unwrap_err();
-    assert_eq!(err.message, "Trailing characters after JSON value");
+    assert!(matches!(
+        err.kind,
+        ErrorKind::Custom(ref msg) if msg.contains("Trailing characters")
+    ));
     assert_eq!(err.index, 5);
     assert_eq!(err.line, 1);
     assert_eq!(err.column, 6);
@@ -41,7 +44,10 @@ fn should_report_trailing_characters_error() {
 #[test]
 fn should_report_trailing_characters_after_object() {
     let err = parse_json("{\"key\": true} extra", None).unwrap_err();
-    assert_eq!(err.message, "Trailing characters after JSON value");
+    assert!(matches!(
+        err.kind,
+        ErrorKind::Custom(ref msg) if msg.contains("Trailing characters")
+    ));
     assert_eq!(err.index, 14);
     assert_eq!(err.line, 1);
     assert_eq!(err.column, 15);
@@ -50,7 +56,10 @@ fn should_report_trailing_characters_after_object() {
 #[test]
 fn should_report_trailing_characters_error_in_strict_mode() {
     let err = parse_json("true false", Some(&JsonParseOptions::strict())).unwrap_err();
-    assert_eq!(err.message, "Trailing characters after JSON value");
+    assert!(matches!(
+        err.kind,
+        ErrorKind::Custom(ref msg) if msg.contains("Trailing characters")
+    ));
     assert_eq!(err.index, 5);
     assert_eq!(err.line, 1);
     assert_eq!(err.column, 6);
@@ -59,7 +68,10 @@ fn should_report_trailing_characters_error_in_strict_mode() {
 #[test]
 fn should_report_trailing_characters_after_object_in_strict_mode() {
     let err = parse_json("{\"key\": true} extra", Some(&JsonParseOptions::strict())).unwrap_err();
-    assert_eq!(err.message, "Trailing characters after JSON value");
+    assert!(matches!(
+        err.kind,
+        ErrorKind::Custom(ref msg) if msg.contains("Trailing characters")
+    ));
     assert_eq!(err.index, 14);
     assert_eq!(err.line, 1);
     assert_eq!(err.column, 15);


### PR DESCRIPTION
- Grouped error variants into logical categories: syntax, string, number, object, and generic
- Alphabetized variants within each group for readability and maintenance
- Rewrote and standardized all doc comments for consistency
- Improved examples and terminology for clarity