### PR TITLE
feat(parser): add reusable parse_key_value_pair function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,6 @@ pub mod parser;
 
 pub use model::{JsonParseError, JsonParseOptions, JsonValue};
 pub use parser::{
-    parse_array, parse_bool, parse_json, parse_null, parse_number, parse_object, parse_string,
+    parse_array, parse_bool, parse_json, parse_key_value_pair, parse_null, parse_number,
+    parse_object, parse_string,
 };

--- a/src/parser/key_value.rs
+++ b/src/parser/key_value.rs
@@ -1,0 +1,60 @@
+use super::{parse_string, parse_value};
+use crate::model::{ErrorKind, JsonParseError, JsonValue};
+
+/// Parses a single `"key": value` pair from a JSON object context.
+///
+/// This is a low-level utility used for streaming or partial parsing use-cases.
+///
+/// # Arguments
+///
+/// * `input` - A string slice expected to start with a quoted string key.
+///
+/// # Returns
+///
+/// * `Ok(((key, value), remaining_input))` on success
+/// * `Err(JsonParseError)` if syntax is invalid or malformed.
+///
+/// # Examples
+///
+/// ```
+/// use synson::parser::parse_key_value_pair;
+/// use synson::model::JsonValue;
+///
+/// let input = r#""name": "John""#;
+/// let ((key, value), rest) = parse_key_value_pair(input).unwrap();
+/// assert_eq!(key, "name");
+/// assert_eq!(value, JsonValue::String("John".into()));
+/// assert_eq!(rest.trim_start(), "");
+/// ```
+pub fn parse_key_value_pair(input: &str) -> Result<((String, JsonValue), &str), JsonParseError> {
+    let original = input;
+    let input = input.trim_start();
+
+    let (key_val, rest) = parse_string(input)
+        .map_err(|e| JsonParseError::new(input, e.index, ErrorKind::ExpectedStringKey))?;
+
+    let JsonValue::String(key) = key_val else {
+        return Err(JsonParseError::new(
+            original,
+            0,
+            ErrorKind::InvalidObjectKey,
+        ));
+    };
+
+    let rest = rest.trim_start();
+
+    if !rest.starts_with(':') {
+        let offset = original.len() - rest.len();
+        return Err(JsonParseError::new(
+            original,
+            offset,
+            ErrorKind::ExpectedColon,
+        ));
+    }
+
+    let rest = &rest[1..];
+    let rest = rest.trim_start();
+
+    let (value, remaining) = parse_value(rest)?;
+    Ok(((key, value), remaining))
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,6 +1,7 @@
 pub mod array;
 pub mod bool;
 pub mod json;
+pub mod key_value;
 pub mod null;
 pub mod number;
 pub mod object;
@@ -10,6 +11,7 @@ pub mod value;
 pub use array::parse_array;
 pub use bool::parse_bool;
 pub use json::parse_json;
+pub use key_value::parse_key_value_pair;
 pub use null::parse_null;
 pub use number::parse_number;
 pub use object::parse_object;

--- a/tests/key_value.rs
+++ b/tests/key_value.rs
@@ -1,0 +1,45 @@
+use synson::{parse_key_value_pair, JsonValue};
+
+#[test]
+fn should_parse_valid_key_value_pairs() {
+    assert_eq!(
+        parse_key_value_pair(r#""key": 42"#),
+        Ok((("key".to_string(), JsonValue::Number(42.0)), ""))
+    );
+
+    assert_eq!(
+        parse_key_value_pair(r#""active": true"#),
+        Ok((("active".to_string(), JsonValue::Bool(true)), ""))
+    );
+
+    assert_eq!(
+        parse_key_value_pair(r#""name": "synson""#),
+        Ok((
+            ("name".to_string(), JsonValue::String("synson".to_string())),
+            ""
+        ))
+    );
+
+    assert_eq!(
+        parse_key_value_pair(r#""data": [1, 2, 3]"#),
+        Ok((
+            (
+                "data".to_string(),
+                JsonValue::Array(vec![
+                    JsonValue::Number(1.0),
+                    JsonValue::Number(2.0),
+                    JsonValue::Number(3.0)
+                ])
+            ),
+            ""
+        ))
+    );
+}
+
+#[test]
+fn should_reject_invalid_keys_or_syntax() {
+    assert!(parse_key_value_pair(r#"123: "bad""#).is_err());
+    assert!(parse_key_value_pair(r#""key" "missing_colon""#).is_err());
+    assert!(parse_key_value_pair(r#""key": "#).is_err());
+    assert!(parse_key_value_pair(r#""key": invalid"#).is_err());
+}


### PR DESCRIPTION
Introduces `parse_key_value_pair` to parse a single JSON "key": value pair. Improves modularity and testability of the parser, and will be reused internally by object parsing logic. Includes strict validation and structured error handling.

+ Added unit tests in tests/key_value.rs
+ Integrated under parser::key_value module